### PR TITLE
Refactor logging and add existence checks for notices and reports

### DIFF
--- a/pkg/convenience/repository/input_raw_references_repository.go
+++ b/pkg/convenience/repository/input_raw_references_repository.go
@@ -79,7 +79,7 @@ func (r *RawInputRefRepository) Create(ctx context.Context, rawInput RawInputRef
 		return err
 	}
 	if exist != nil {
-		slog.Warn("Raw input already exists. Skipping creation")
+		slog.Debug("Raw input already exists. Skipping creation")
 		return nil
 	}
 

--- a/pkg/convenience/repository/input_repository.go
+++ b/pkg/convenience/repository/input_repository.go
@@ -84,7 +84,7 @@ func (r *InputRepository) Create(ctx context.Context, input model.AdvanceInput) 
 		return nil, err
 	}
 	if exist != nil {
-		slog.Warn("Input already exists. Skipping creation")
+		slog.Debug("Input already exists. Skipping creation")
 		return exist, nil
 	}
 	return r.rawCreate(ctx, input)

--- a/pkg/convenience/repository/notice_repository.go
+++ b/pkg/convenience/repository/notice_repository.go
@@ -51,6 +51,16 @@ func (c *NoticeRepository) Create(
 		data.OutputIndex = count
 		data.ProofOutputIndex = count
 	}
+	address := common.HexToAddress(data.AppContract)
+	dbInstance, err := c.FindNoticeByOutputIndexAndAppContract(ctx, data.OutputIndex, &address)
+	if err != nil {
+		return nil, err
+	}
+	if dbInstance != nil {
+		slog.Debug("Notice already exists", "output_index", data.OutputIndex, "app_contract", data.AppContract)
+		return dbInstance, nil
+	}
+
 	insertSql := `INSERT INTO convenience_notices (
 		payload,
 		input_index,
@@ -60,7 +70,7 @@ func (c *NoticeRepository) Create(
 		proof_output_index) VALUES ($1, $2, $3, $4, $5, $6)`
 
 	exec := DBExecutor{&c.Db}
-	_, err := exec.ExecContext(ctx,
+	_, err = exec.ExecContext(ctx,
 		insertSql,
 		data.Payload,
 		data.InputIndex,

--- a/pkg/convenience/repository/notice_repository_test.go
+++ b/pkg/convenience/repository/notice_repository_test.go
@@ -94,11 +94,13 @@ func (s *NoticeRepositorySuite) TestCountNotices() {
 
 func (s *NoticeRepositorySuite) TestNoticePagination() {
 	ctx := context.Background()
+	appContract := common.HexToAddress(ApplicationAddress)
 	for i := 0; i < 30; i++ {
 		_, err := s.repository.Create(ctx, &model.ConvenienceNotice{
 			Payload:     "0x0011",
 			InputIndex:  uint64(i),
-			OutputIndex: 0,
+			OutputIndex: uint64(i),
+			AppContract: appContract.Hex(),
 		})
 		s.NoError(err)
 	}

--- a/pkg/convenience/repository/report_repository_test.go
+++ b/pkg/convenience/repository/report_repository_test.go
@@ -45,10 +45,12 @@ func (s *ReportRepositorySuite) TestCreateTables() {
 
 func (s *ReportRepositorySuite) TestCreateReport() {
 	ctx := context.Background()
+	appContract := common.HexToAddress(configtest.DEFAULT_TEST_APP_CONTRACT[2:])
 	_, err := s.reportRepository.CreateReport(ctx, cModel.Report{
-		Index:      1,
-		InputIndex: 2,
-		Payload:    "1122",
+		Index:       1,
+		InputIndex:  2,
+		Payload:     "1122",
+		AppContract: appContract,
 	})
 	s.NoError(err)
 }
@@ -86,14 +88,16 @@ func (s *ReportRepositorySuite) TestReportNotFound() {
 
 func (s *ReportRepositorySuite) TestCreateReportAndFindAll() {
 	ctx := context.Background()
+	appContract := common.HexToAddress(configtest.DEFAULT_TEST_APP_CONTRACT[2:])
 	for i := 0; i < 3; i++ {
 		for j := 0; j < 4; j++ {
 			_, err := s.reportRepository.CreateReport(
 				ctx,
 				cModel.Report{
-					InputIndex: i,
-					Index:      j,
-					Payload:    "1122",
+					InputIndex:  i,
+					Index:       i * j,
+					Payload:     "1122",
+					AppContract: appContract,
 				})
 			s.NoError(err)
 		}

--- a/pkg/convenience/repository/report_repository_test.go
+++ b/pkg/convenience/repository/report_repository_test.go
@@ -89,24 +89,22 @@ func (s *ReportRepositorySuite) TestReportNotFound() {
 func (s *ReportRepositorySuite) TestCreateReportAndFindAll() {
 	ctx := context.Background()
 	appContract := common.HexToAddress(configtest.DEFAULT_TEST_APP_CONTRACT[2:])
-	for i := 0; i < 3; i++ {
-		for j := 0; j < 4; j++ {
-			_, err := s.reportRepository.CreateReport(
-				ctx,
-				cModel.Report{
-					InputIndex:  i,
-					Index:       i * j,
-					Payload:     "1122",
-					AppContract: appContract,
-				})
-			s.NoError(err)
-		}
+	for i := 0; i < 12; i++ {
+		_, err := s.reportRepository.CreateReport(
+			ctx,
+			cModel.Report{
+				InputIndex:  i,
+				Index:       i,
+				Payload:     "1122",
+				AppContract: appContract,
+			})
+		s.NoError(err)
 	}
 	reports, err := s.reportRepository.FindAll(ctx, nil, nil, nil, nil, nil)
 	s.NoError(err)
 	s.Equal(12, int(reports.Total))
 	s.Equal(0, reports.Rows[0].InputIndex)
-	s.Equal(2, reports.Rows[len(reports.Rows)-1].InputIndex)
+	s.Equal(11, reports.Rows[len(reports.Rows)-1].InputIndex)
 
 	filter := []*cModel.ConvenienceFilter{}
 	{
@@ -119,11 +117,11 @@ func (s *ReportRepositorySuite) TestCreateReportAndFindAll() {
 	}
 	reports, err = s.reportRepository.FindAll(ctx, nil, nil, nil, nil, filter)
 	s.NoError(err)
-	s.Equal(4, int(reports.Total))
+	s.Equal(1, int(reports.Total))
 	s.Equal(1, reports.Rows[0].InputIndex)
-	s.Equal(0, reports.Rows[0].Index)
+	s.Equal(1, reports.Rows[0].Index)
 	s.Equal(1, reports.Rows[len(reports.Rows)-1].InputIndex)
-	s.Equal(3, reports.Rows[len(reports.Rows)-1].Index)
+	s.Equal(1, reports.Rows[len(reports.Rows)-1].Index)
 	s.Equal("0x1122", reports.Rows[0].Payload)
 }
 


### PR DESCRIPTION
Change log level for existing input messages from Warn to Debug. Introduce checks to prevent duplicate entries for notices and reports before insertion.