### PR TITLE
Bump PostgreSQL version to 17.4

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM postgres:16.6-bookworm
+FROM postgres:17.4-bookworm
 
 ENV POSTGRES_DB=mydatabase
 ENV POSTGRES_USER=myuser

--- a/postgres/raw/Dockerfile
+++ b/postgres/raw/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16-alpine
+FROM postgres:17.4-alpine3.21
 
 # Copy the SQL files to the container
 RUN mkdir -v /sql


### PR DESCRIPTION
Update Dockerfiles to use PostgreSQL version 17.4 for both bookworm and alpine images.