### PR TITLE
fix: triggering a new version on ci

### DIFF
--- a/.changeset/honest-parents-sniff.md
+++ b/.changeset/honest-parents-sniff.md
@@ -1,0 +1,5 @@
+---
+"rollups-graphql": patch
+---
+
+Fixes on ci releases


### PR DESCRIPTION
triggering a new version on ci