### PR TITLE
Update database connection environment variables

### DIFF
--- a/.changeset/spicy-meals-ask.md
+++ b/.changeset/spicy-meals-ask.md
@@ -1,0 +1,5 @@
+---
+"rollups-graphql": minor
+---
+
+Change database environment variables

--- a/.github/workflows/loadtest.yaml
+++ b/.github/workflows/loadtest.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Using Postgres DB
         run: |
           export POSTGRES_GRAPHQL_DB_URL="postgres://postgres:password@localhost:5432/rlgraphql?sslmode=disable"
-          export POSTGRES_NODE_DB_URL="postgres://postgres:password@localhost:5432/rollupsdb?sslmode=disable"
+          export CARTESI_DATABASE_CONNECTION="postgres://postgres:password@localhost:5432/rollupsdb?sslmode=disable"
           nohup ./cartesi-rollups-graphql -d --db-implementation=postgres &
           sleep 10
 

--- a/.github/workflows/loadtest.yaml
+++ b/.github/workflows/loadtest.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Using Postgres DB
         run: |
-          export POSTGRES_GRAPHQL_DB_URL="postgres://postgres:password@localhost:5432/rlgraphql?sslmode=disable"
+          export CARTESI_GRAPHQL_DATABASE_CONNECTION="postgres://postgres:password@localhost:5432/rlgraphql?sslmode=disable"
           export CARTESI_DATABASE_CONNECTION="postgres://postgres:password@localhost:5432/rollupsdb?sslmode=disable"
           nohup ./cartesi-rollups-graphql -d --db-implementation=postgres &
           sleep 10

--- a/DEV2DEV.md
+++ b/DEV2DEV.md
@@ -53,7 +53,7 @@ go run . --enable-debug
 ```
 
 ```shell
-export POSTGRES_GRAPHQL_DB_URL="postgres://postgres:password@127.0.0.1:5432/hlgraphql?sslmode=disable"
+export CARTESI_GRAPHQL_DATABASE_CONNECTION="postgres://postgres:password@127.0.0.1:5432/hlgraphql?sslmode=disable"
 export CARTESI_DATABASE_CONNECTION="postgres://postgres:password@localhost:5432/rollupsdb?sslmode=disable"
 go run . --http-address=0.0.0.0 --enable-debug
 ```
@@ -70,7 +70,7 @@ make clean-db-raw
 
 The following environment variables are used for PostgreSQL configuration:
 
-- `POSTGRES_GRAPHQL_DB_URL`: URL for the PostgreSQL database used by GraphQL.
+- `CARTESI_GRAPHQL_DATABASE_CONNECTION`: URL for the PostgreSQL database used by GraphQL.
 - `CARTESI_DATABASE_CONNECTION`: URL for the PostgreSQL database used by the node.
 - `DB_MAX_OPEN_CONNS`: Maximum number of open connections to the database (default: 25).
 - `DB_MAX_IDLE_CONNS`: Maximum number of idle connections in the pool (default: 10).

--- a/DEV2DEV.md
+++ b/DEV2DEV.md
@@ -54,7 +54,7 @@ go run . --enable-debug
 
 ```shell
 export POSTGRES_GRAPHQL_DB_URL="postgres://postgres:password@127.0.0.1:5432/hlgraphql?sslmode=disable"
-export POSTGRES_NODE_DB_URL="postgres://postgres:password@localhost:5432/rollupsdb?sslmode=disable"
+export CARTESI_DATABASE_CONNECTION="postgres://postgres:password@localhost:5432/rollupsdb?sslmode=disable"
 go run . --http-address=0.0.0.0 --enable-debug
 ```
 
@@ -71,7 +71,7 @@ make clean-db-raw
 The following environment variables are used for PostgreSQL configuration:
 
 - `POSTGRES_GRAPHQL_DB_URL`: URL for the PostgreSQL database used by GraphQL.
-- `POSTGRES_NODE_DB_URL`: URL for the PostgreSQL database used by the node.
+- `CARTESI_DATABASE_CONNECTION`: URL for the PostgreSQL database used by the node.
 - `DB_MAX_OPEN_CONNS`: Maximum number of open connections to the database (default: 25).
 - `DB_MAX_IDLE_CONNS`: Maximum number of idle connections in the pool (default: 10).
 - `DB_CONN_MAX_LIFETIME`: Maximum amount of time a connection may be reused (default: 1800 seconds).

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ New releases are created using the [Changesets](https://github.com/changesets/ch
 
 3. **'push' your changes to remote repo**
 
-   No github action is trigered until here.
+   No GitHub action is triggered until here.
 
 4. **New Pull Request**
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ make up-db-raw
 ```
 
 ```shell
-export POSTGRES_GRAPHQL_DB_URL="postgres://postgres:password@127.0.0.1:5432/hlgraphql?sslmode=disable"
+export CARTESI_GRAPHQL_DATABASE_CONNECTION="postgres://postgres:password@127.0.0.1:5432/hlgraphql?sslmode=disable"
 export CARTESI_DATABASE_CONNECTION="postgres://postgres:password@localhost:5432/rollupsdb?sslmode=disable"
 go run . --http-address=0.0.0.0
 ```
@@ -56,7 +56,7 @@ go build -o cartesi-rollups-graphql
 Run the rollups graphql:
 
 ```shell
-export POSTGRES_GRAPHQL_DB_URL="postgres://postgres:password@localhost:5432/hlgraphql?sslmode=disable"
+export CARTESI_GRAPHQL_DATABASE_CONNECTION="postgres://postgres:password@localhost:5432/hlgraphql?sslmode=disable"
 export CARTESI_DATABASE_CONNECTION="postgres://postgres:password@localhost:5432/rollupsdb?sslmode=disable"
 ./cartesi-rollups-graphql
 ```
@@ -65,7 +65,7 @@ export CARTESI_DATABASE_CONNECTION="postgres://postgres:password@localhost:5432/
 
 The following environment variables are used for PostgreSQL configuration:
 
-- `POSTGRES_GRAPHQL_DB_URL`: URL for the PostgreSQL database used by GraphQL.
+- `CARTESI_GRAPHQL_DATABASE_CONNECTION`: URL for the PostgreSQL database used by GraphQL.
 - `CARTESI_DATABASE_CONNECTION`: URL for the PostgreSQL database used by the node.
 - `DB_MAX_OPEN_CONNS`: Maximum number of open connections to the database (default: 25).
 - `DB_MAX_IDLE_CONNS`: Maximum number of idle connections in the pool (default: 10).
@@ -78,7 +78,6 @@ The following environment variables are used for PostgreSQL configuration:
 
 Made with [contributors-img](https://contributors-img.firebaseapp.com).
 
-
 ## Release
 
 New releases are created using the [Changesets](https://github.com/changesets/changesets/blob/main/packages/cli/README.md) library, which is already set up in this project.
@@ -88,25 +87,26 @@ New releases are created using the [Changesets](https://github.com/changesets/ch
 #### Manual steps
 
 1. **Workflow permissions**:
+
    - Ensure this repository has "Read and write permissions" enabled under the "Workflow permissions" section in the repository settings.
 
 2. **Create a changeset when you're ready to release a new version**:
+
    ```bash
    npx changeset
    ```
+
    - Select the type of change (patch, minor, major)
    - Write a short description of the change
    - Make sure a `.md` file is automatically created inside the `.changeset/` directory
 
 3. **'push' your changes to remote repo**
 
-    No github action is trigered until here.
+   No github action is trigered until here.
 
-3. **New Pull Request**
+4. **New Pull Request**
 
-    Create a pull request from your branch into `main` branch.
-
-
+   Create a pull request from your branch into `main` branch.
 
 #### Automatic procedures
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ make up-db-raw
 
 ```shell
 export POSTGRES_GRAPHQL_DB_URL="postgres://postgres:password@127.0.0.1:5432/hlgraphql?sslmode=disable"
-export POSTGRES_NODE_DB_URL="postgres://postgres:password@localhost:5432/rollupsdb?sslmode=disable"
+export CARTESI_DATABASE_CONNECTION="postgres://postgres:password@localhost:5432/rollupsdb?sslmode=disable"
 go run . --http-address=0.0.0.0
 ```
 
@@ -57,7 +57,7 @@ Run the rollups graphql:
 
 ```shell
 export POSTGRES_GRAPHQL_DB_URL="postgres://postgres:password@localhost:5432/hlgraphql?sslmode=disable"
-export POSTGRES_NODE_DB_URL="postgres://postgres:password@localhost:5432/rollupsdb?sslmode=disable"
+export CARTESI_DATABASE_CONNECTION="postgres://postgres:password@localhost:5432/rollupsdb?sslmode=disable"
 ./cartesi-rollups-graphql
 ```
 
@@ -66,7 +66,7 @@ export POSTGRES_NODE_DB_URL="postgres://postgres:password@localhost:5432/rollups
 The following environment variables are used for PostgreSQL configuration:
 
 - `POSTGRES_GRAPHQL_DB_URL`: URL for the PostgreSQL database used by GraphQL.
-- `POSTGRES_NODE_DB_URL`: URL for the PostgreSQL database used by the node.
+- `CARTESI_DATABASE_CONNECTION`: URL for the PostgreSQL database used by the node.
 - `DB_MAX_OPEN_CONNS`: Maximum number of open connections to the database (default: 25).
 - `DB_MAX_IDLE_CONNS`: Maximum number of idle connections in the pool (default: 10).
 - `DB_CONN_MAX_LIFETIME`: Maximum amount of time a connection may be reused (default: 1800 seconds).
@@ -100,11 +100,11 @@ New releases are created using the [Changesets](https://github.com/changesets/ch
 
 3. **'push' your changes to remote repo**
 
-    No github action is trigered until here. 
+    No github action is trigered until here.
 
 3. **New Pull Request**
 
-    Create a pull request from your branch into `main` branch. 
+    Create a pull request from your branch into `main` branch.
 
 
 

--- a/dev/main.go
+++ b/dev/main.go
@@ -113,7 +113,7 @@ func main() {
 	var s *Schema
 	var err error
 
-	postgresEndpoint := os.Getenv("POSTGRES_GRAPHQL_DB_URL")
+	postgresEndpoint := os.Getenv("CARTESI_GRAPHQL_DATABASE_CONNECTION")
 
 	uri, err := url.Parse(postgresEndpoint)
 	if err == nil {

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -85,9 +85,9 @@ func NewSupervisorGraphQL(opts BootstrapOpts) supervisor.SupervisorWorker {
 	})
 
 	if !opts.DisableSync {
-		dbRawUrl, ok := os.LookupEnv("POSTGRES_NODE_DB_URL")
+		dbRawUrl, ok := os.LookupEnv("CARTESI_DATABASE_CONNECTION")
 		if !ok {
-			panic("POSTGRES_NODE_DB_URL environment variable not set")
+			panic("CARTESI_DATABASE_CONNECTION environment variable not set")
 		}
 		dbNodeV2 := sqlx.MustConnect("postgres", dbRawUrl)
 		rawRepository := synchronizernode.NewRawRepository(dbRawUrl, dbNodeV2)

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -186,11 +186,11 @@ func CreateDBInstance(opts BootstrapOpts) *sqlx.DB {
 			"dbname=%s password=%s sslmode=disable",
 			postgresHost, postgresPort, postgresUser,
 			postgresDataBase, postgresPassword)
-		dbUrl, ok := os.LookupEnv("POSTGRES_GRAPHQL_DB_URL")
+		dbUrl, ok := os.LookupEnv("CARTESI_GRAPHQL_DATABASE_CONNECTION")
 		if ok {
 			connectionString = dbUrl
 		} else {
-			slog.Warn("The environment variables POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DB, POSTGRES_USER, and POSTGRES_PASSWORD are deprecated. Please use POSTGRES_GRAPHQL_DB_URL instead.")
+			slog.Warn("The environment variables POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DB, POSTGRES_USER, and POSTGRES_PASSWORD are deprecated. Please use CARTESI_GRAPHQL_DATABASE_CONNECTION instead.")
 		}
 		db = sqlx.MustConnect("postgres", connectionString)
 		configureConnectionPool(db)


### PR DESCRIPTION
Change the database connection environment variables from `POSTGRES_GRAPHQL_DB_URL` and `POSTGRES_NODE_DB_URL` to `CARTESI_GRAPHQL_DATABASE_CONNECTION` and `CARTESI_DATABASE_CONNECTION` for improved clarity and consistency. Update related code references accordingly.